### PR TITLE
底部导航不跟随路由的切换变化而变化

### DIFF
--- a/src/components/TabBar.vue
+++ b/src/components/TabBar.vue
@@ -30,20 +30,24 @@
 </template>
 
 <script lang="ts" setup>
-  import { useRoute } from 'vue-router'
-  import { useGlobalStore } from '@/store/global'
-  import { storeToRefs } from 'pinia'
+  import { useRoute, onBeforeRouteUpdate } from 'vue-router';
+  import { useGlobalStore } from '@/store/global';
+  import { storeToRefs } from 'pinia';
+  import { ref } from 'vue';
 
-  const route = useRoute()
-  const routeList = ['/subs', '/sync', '/my']
-  const activeTab = routeList.indexOf(route.path)
+  const route = useRoute();
+  const routeList = ['/subs', '/sync', '/my'];
+  let activeTab = ref(routeList.indexOf(route.path));
+  onBeforeRouteUpdate(to => {
+    activeTab.value = routeList.indexOf(to.fullPath);
+  });
 
-  const globalStore = useGlobalStore()
-  const { bottomSafeArea } = storeToRefs(globalStore)
+  const globalStore = useGlobalStore();
+  const { bottomSafeArea } = storeToRefs(globalStore);
   const style = {
     height: `${bottomSafeArea.value + 12 + 44}px`,
     paddingBottom: bottomSafeArea.value + 'px',
-  }
+  };
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
在浏览器端的时候，使用后退前进等相关功能的时候，切换有时候有点不太方便。大佬看看代码如果可以的话希望优化一下。