### PR TITLE
fix: adjust bottom safe area on legacy devices

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,12 +26,13 @@
 
   const allLength = ref(null);
 
-  // 处于 pwa 时将底部安全距离写入 global store
+  // 处于 pwa 且屏幕底部有小白条时将底部安全距离写入 global store
   type NavigatorExtend = Navigator & {
     standalone?: boolean;
   };
   const navigator: NavigatorExtend = window.navigator;
-  globalStore.setBottomSafeArea(navigator.standalone ? 18 : 0);
+  const hasHomeIndicator: boolean = window.matchMedia('(max-height: 812px) and (-webkit-touch-edge: pan-down)').matches;
+  globalStore.setBottomSafeArea(navigator.standalone && hasHomeIndicator ? 18 : 0);
 
   // 如果带有 url 参数配置 api，则将其添加到 api 列表并切换
   const { handleUrlQuery } = useHostAPI();


### PR DESCRIPTION
When opening the sub-store in PWA mode on a legacy device (such as iPhone SE 2020), unnecessary blank space will appear at the bottom. This should be designed for full-screen devices, but it is inconsistent when it appears on non-full-screen devices as shown below:

![IMG_0625](https://github.com/sub-store-org/Sub-Store-Front-End/assets/122220163/0149015e-d648-4997-b17a-38a026df4651)

Unexpected padding space may appear at the bottom of the screen.

---

In this pull request I fixed the issue and now it should work fine as shown below:

![IMG_0624](https://github.com/sub-store-org/Sub-Store-Front-End/assets/122220163/175e0375-6038-4181-997d-1d4face1a4b1)

Please the admin of this repository check this pull request, thanks.


