### PR TITLE
draggable component using element id instead of index

### DIFF
--- a/src/views/editor/ActionBlock.vue
+++ b/src/views/editor/ActionBlock.vue
@@ -33,13 +33,13 @@
 }" @end="drag = false" @start="drag = true" item-key="id">
       <template #item="{ element, index }">
         <nut-cell class="list-group-item" aria-hidden="true">
-          <div :class="{ 'list-group-item-title': true, 'collapsed': collapsedElements.includes(index) }">
+          <div :class="{ 'list-group-item-title': true, 'collapsed': collapsedElements.includes(element.id) }">
             <div class="title-text left">
-              <span class="collapsed" @click="toggleElementCollapsed(index)">
-                <nut-icon v-if="!collapsedElements.includes(index)" name="rect-down" size="12px"></nut-icon>
-                <nut-icon v-if="collapsedElements.includes(index)" name="rect-right" size="12px"></nut-icon>
+              <span class="collapsed" @click="toggleElementCollapsed(element.id)">
+                <nut-icon v-if="!collapsedElements.includes(element.id)" name="rect-down" size="12px"></nut-icon>
+                <nut-icon v-if="collapsedElements.includes(element.id)" name="rect-right" size="12px"></nut-icon>
               </span>
-              <span class="name" @click="toggleElementCollapsed(index)">{{
+              <span class="name" @click="toggleElementCollapsed(element.id)">{{
                 $t(`editorPage.subConfig.nodeActions['${element.type}'].label`)
               }}</span>
               <font-awesome-icon icon="fa-solid fa-circle-question" @click="pop(element.type, element.tipsDes)" />
@@ -63,7 +63,7 @@
               </div>
             </div>
           </div>
-          <Component v-show="!collapsedElements.includes(index)" :is="element.component" :type="element.type" :id="element.id" :sourceType="sourceType"/>
+          <Component v-show="!collapsedElements.includes(element.id)" :is="element.component" :type="element.type" :id="element.id" :sourceType="sourceType"/>
         </nut-cell>
       </template>
     </Draggable>
@@ -170,7 +170,7 @@ const columns = ref(items);
 // useMousePicker();
 
 if(isCollapsed.value) {
-  collapsedElements.value = [...Array(list.length).keys()];
+  collapsedElements.value = list.map((item) => item.id);
 } else {
   collapsedElements.value = [];
 }
@@ -178,17 +178,17 @@ const setCollapsed = (v) => {
   isCollapsed.value = v;
   if (v) {
     localStorage.setItem('actions-block-collapsed', '1')
-    collapsedElements.value = [...Array(list.length).keys()];
+    collapsedElements.value = list.map((item) => item.id);
   } else {
     localStorage.removeItem('actions-block-collapsed')
     collapsedElements.value = [];
   }
 };
-const toggleElementCollapsed = (index) => {
-  if (collapsedElements.value.includes(index)) {
-    collapsedElements.value = collapsedElements.value.filter(item => item !== index);
+const toggleElementCollapsed = (id) => {
+  if (collapsedElements.value.includes(id)) {
+    collapsedElements.value = collapsedElements.value.filter(item => item !== id);
   } else {
-    collapsedElements.value.push(index);
+    collapsedElements.value.push(id);
   }
   if(collapsedElements.value.length === list.length) {
     setCollapsed(true)


### PR DESCRIPTION
如果组件在展开状态下拖动换位时会发生预期外的情况
原因：不能用index来跟踪组件的collapse state, 会导致关系错乱
解决办法：使用元素的唯一id