### PR TITLE
修复 ActionBlock.vue 中 watch 解构 props 导致的 Vue 3.5+ 构建失败

### DIFF
--- a/src/views/editor/ActionBlock.vue
+++ b/src/views/editor/ActionBlock.vue
@@ -400,7 +400,7 @@ const inCustomNameEditMode = computed(() =>
   editNameList.map((item) => item.isEditing).includes(true),
 );
 
-watch(list, (newV: ActionModuleProps[]) => {
+watch(() => list, (newV: ActionModuleProps[]) => {
   if (editNameList.length > newV.length) {
     // delete
     const elementsToDelete = editNameList.filter(


### PR DESCRIPTION
- 将 watch(list, ...) 修改为 watch(() => list, ...) ，以兼容 Vue 3.5+ 对解构 props 直接传递给 watch 的严格校验。
- 该变动解决了云端（如 Cloudflare Pages）构建失败的问题，保证本地和云端环境均可正常编译。
- 不影响原有功能和响应式逻辑，仅为兼容性修复