### PR TITLE
fix: separate SurgeMac label and info icon to prevent unwanted navigation

### DIFF
--- a/src/components/ArtifactPanel.vue
+++ b/src/components/ArtifactPanel.vue
@@ -122,7 +122,7 @@
             <nut-radio label="Clash">Clash(Deprecated)</nut-radio>
             <nut-radio label="Egern">Egern</nut-radio>
             <nut-radio label="Surfboard">Surfboard</nut-radio>
-            <nut-radio label="SurgeMac"><a href="https://github.com/sub-store-org/Sub-Store/wiki/%E9%93%BE%E6%8E%A5%E5%8F%82%E6%95%B0%E8%AF%B4%E6%98%8E" target="_blank">Surge(macOS) ⓘ</a></nut-radio>
+            <nut-radio label="SurgeMac">Surge(macOS) <a href="https://github.com/sub-store-org/Sub-Store/wiki/%E9%93%BE%E6%8E%A5%E5%8F%82%E6%95%B0%E8%AF%B4%E6%98%8E" target="_blank">ⓘ</a></nut-radio>
             <nut-radio label="Surge">Surge</nut-radio>
             <nut-radio label="Loon">Loon</nut-radio>
             <nut-radio label="ShadowRocket">Shadowrocket</nut-radio>


### PR DESCRIPTION
When users click on the "Surge(macOS)" radio option, they should be able to select it without being redirected to documentation. This commit ensures only clicking on the info icon (ⓘ) will navigate to the documentation link.

Please see the following GIF:
![CleanShot 2025-05-15 at 15 51 33](https://github.com/user-attachments/assets/e2bffd7c-d996-4625-8dde-cc73ce36aa0f)
