### PR TITLE
fix: ensure arrow icon rotation on swipe actions

### DIFF
--- a/src/components/SubListItem.vue
+++ b/src/components/SubListItem.vue
@@ -647,6 +647,7 @@ const setIsMoveOpen = () => {
 
   setTimeout(() => {
     swipeIsOpen.value = true;
+    if (moreAction.value) moreAction.value.style.transform = "rotate(180deg)";
   }, 100);
 
   setTimeoutTF();


### PR DESCRIPTION
- Update arrow icon rotation state when left swipe is activated
- Ensure consistent UI behavior between manual button click and swipe gesture
- Fix issue where arrow icon would not rotate when using swipe gesture

Please see the following GIF：
![CleanShot 2025-05-15 at 19 45 37](https://github.com/user-attachments/assets/cf2f293a-c04b-4ee4-8bcc-a5305e675561)
