### PR TITLE
feat: support backend configuration via URL api parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sub-store-front-end",
-  "version": "2.15.28",
+  "version": "2.15.29",
   "private": true,
   "scripts": {
     "dev": "vite --host",

--- a/src/components/MagicPathDialog.vue
+++ b/src/components/MagicPathDialog.vue
@@ -16,6 +16,12 @@
       <div class="title">{{ $t('magicPath.title') }}</div>
       <div class="description" v-html="$t('magicPath.description')"></div>
 
+      <!-- 显示URL参数错误信息 -->
+      <div v-if="props.urlApiError" class="url-api-error">
+        <nut-icon name="failure" size="16"></nut-icon>
+        <span>{{ props.urlApiError }}</span>
+      </div>
+
       <div class="input-container">
         <nut-input
           v-model="magicPath"
@@ -88,6 +94,7 @@ const { addApi, setCurrent } = useHostAPI();
 
 const props = defineProps<{
   modelValue: boolean;
+  urlApiError?: string;
 }>();
 
 const emit = defineEmits<{
@@ -243,13 +250,24 @@ const validateInput = () => {
   return true;
 };
 
-// 当对话框关闭时重置状态
+// 当对话框关闭时重置状态，当对话框打开时检查URL参数错误
 watch(visible, (newValue) => {
   if (!newValue) {
     magicPath.value = '';
     error.value = '';
     // 清除sessionStorage中的状态
     sessionStorage.removeItem('showMagicPathDialog');
+  } else if (newValue && props.urlApiError) {
+    // 如果有URL参数错误信息，显示在错误提示中
+    error.value = props.urlApiError;
+  }
+});
+
+// 监听URL参数错误信息的变化
+watch(() => props.urlApiError, (newValue) => {
+  if (newValue && visible.value) {
+    // 如果有新的URL参数错误信息且对话框正在显示，更新错误提示
+    error.value = newValue;
   }
 });
 
@@ -339,6 +357,27 @@ watchEffect(() => {
     :deep(a) {
       color: var(--primary-color);
       text-decoration: none;
+    }
+  }
+
+  .url-api-error {
+    margin-bottom: 20px;
+    padding: 10px;
+    border-radius: 8px;
+    background-color: rgba(255, 0, 0, 0.05);
+    border: 1px solid var(--danger-color);
+    color: var(--danger-color);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+
+    .nut-icon {
+      flex-shrink: 0;
+    }
+
+    span {
+      flex: 1;
     }
   }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -889,10 +889,13 @@ export default {
       currentTag: "Current",
     },
     addApi: {
-      title: "Add New Backend",
+      title: "Add New Backend Connection",
       placeholder: {
         name: "Please input backend name, must be unique",
-        url: "Please input the full URL of the backend",
+        url: "Please input backend path or address",
+      },
+      errors: {
+        nameEmpty: "Name cannot be empty",
       },
       btn: "Add",
     },

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -878,10 +878,13 @@ export default {
       currentTag: '当前',
     },
     addApi: {
-      title: '添加新后端',
+      title: '添加新的后端连接配置',
       placeholder: {
         name: '请输入后端名称，必须唯一',
-        url: '请输入完整后端地址',
+        url: '请输入后端路径或地址',
+      },
+      errors: {
+        nameEmpty: '名称不能为空',
       },
       btn: '添加',
     },

--- a/src/utils/initApp.ts
+++ b/src/utils/initApp.ts
@@ -34,12 +34,45 @@ export const initStores = async (
   // 更新所有数据
   try {
     localStorage.removeItem("envCache");
+
+    // 尝试获取后端环境信息，这是判断后端连接是否成功的关键
+    try {
+      // 设置超时，如果3秒内无法连接，则认为连接失败
+      const timeoutPromise = new Promise((_, reject) => {
+        setTimeout(() => {
+          reject(new Error('Backend connection timeout'));
+        }, 3000); // 3秒超时
+      });
+
+      // 尝试获取环境信息
+      const envPromise = globalStore.setEnv();
+
+      // 使用Promise.race，哪个先完成就用哪个结果
+      await Promise.race([envPromise, timeoutPromise]);
+
+      // 检查是否成功获取到后端环境信息
+      const hasBackendEnv = Object.keys(globalStore.env).length > 0 && globalStore.env.backend;
+      if (!hasBackendEnv) {
+        // 如果没有获取到后端环境信息，说明连接失败
+        console.error('Failed to get backend environment info');
+        globalStore.setFetchResult(false);
+        isSucceed = false;
+        throw new Error('Failed to get backend environment info');
+      }
+    } catch (envError) {
+      console.error('Error getting backend environment:', envError);
+      globalStore.setFetchResult(false);
+      isSucceed = false;
+      throw envError; // 重新抛出异常，中断后续操作
+    }
+
+    // 只有在成功获取环境信息后才继续获取其他数据
     await subsStore.fetchSubsData();
     await new Promise((resolve) => setTimeout(resolve, 50));
     await artifactsStore.fetchArtifactsData();
     await settingsStore.syncLocalAppearanceSetting();
     await settingsStore.fetchSettings();
-    await globalStore.setEnv();
+
     if (needRefreshCache) {
       const { data } = await useEnvApi().refreshCache();
       if (data.status !== "success") {
@@ -48,6 +81,7 @@ export const initStores = async (
       }
     }
   } catch (e) {
+    console.error('Error initializing stores:', e);
     globalStore.setFetchResult(false);
     subsStore.subs = [];
     subsStore.collections = [];


### PR DESCRIPTION
Add support for specifying backend API via URL parameter like: http://127.0.0.1:8888/subs?api=http://127.0.0.1:3001/XXXXXxx

- Improve backend connection detection logic
- Show configuration dialog when URL-specified backend is unreachable
- Auto-connect to backend when URL parameter is valid
- Fix issues with empty backend data detection