### PR TITLE
fix: improve backend connection and error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sub-store-front-end",
-  "version": "2.15.31",
+  "version": "2.15.32",
   "private": true,
   "scripts": {
     "dev": "vite --host",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sub-store-front-end",
-  "version": "2.15.32",
+  "version": "2.15.33",
   "private": true,
   "scripts": {
     "dev": "vite --host",

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@
   <MagicPathDialog
     v-model="showMagicPathDialog"
     :url-api-error="urlApiError"
+    :url-api-value="urlApiValue"
     :connection-cycle="connectionCheckCycle"
   />
 </template>
@@ -66,6 +67,7 @@ globalStore.setBottomSafeArea(
 const { handleUrlQuery } = useHostAPI();
 const urlApiConfigSuccess = ref(false);
 const urlApiError = ref('');
+const urlApiValue = ref('');
 
 const processUrlApiConfig = async () => {
   // 设置检查状态为进行中
@@ -92,9 +94,15 @@ const processUrlApiConfig = async () => {
       .find(i => i[0] === 'magicpath');
 
     if (hasApiParam) {
+      const apiValue = decodeURIComponent(hasApiParam[1]);
+      urlApiValue.value = apiValue;
       urlApiError.value = '通过 URL 参数指定的 API 地址连接失败，请检查地址是否正确';
       hasUrlParams = true;
     } else if (hasMagicPathParam) {
+      const magicPath = decodeURIComponent(hasMagicPathParam[1]);
+      const currentHost = window.location.origin;
+      const apiUrl = `${currentHost}/${magicPath.replace(/^\/+/, '')}`;
+      urlApiValue.value = apiUrl;
       urlApiError.value = '通过 URL 参数指定的 magicpath 连接失败，请检查路径是否正确';
       hasUrlParams = true;
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@
   <MagicPathDialog
     v-model="showMagicPathDialog"
     :url-api-error="urlApiError"
+    :connection-cycle="connectionCheckCycle"
   />
 </template>
 
@@ -36,6 +37,8 @@ const allLength = ref(null);
 const showMagicPathDialog = ref(false);
 // 添加状态变量，用于跟踪后端连接状态的检查过程
 const isBackendCheckInProgress = ref(true);
+// 添加状态变量，用于跟踪当前的连接检测周期
+const connectionCheckCycle = ref(Date.now());
 
 // 处于 pwa 且屏幕底部有小白条时将底部安全距离写入 global store
 type NavigatorExtend = Navigator & {
@@ -68,12 +71,15 @@ const processUrlApiConfig = async () => {
   // 设置检查状态为进行中
   isBackendCheckInProgress.value = true;
 
+  // 更新连接检测周期
+  connectionCheckCycle.value = Date.now();
+
   const query = window.location.search;
   let hasUrlParams = false;
 
   // 检查URL参数
   if (query) {
-    
+
     const hasApiParam = query
       .slice(1)
       .split('&')
@@ -98,6 +104,9 @@ const processUrlApiConfig = async () => {
   const result = await handleUrlQuery({
     errorCb: async () => {
       try {
+        // 检查用户是否跳过了当前连接检测周期
+        const skippedCycle = parseInt(sessionStorage.getItem('skippedConnectionCycle') || '0');
+
         // 尝试初始化stores，获取后端环境信息
         await initStores(true, true, false);
 
@@ -110,21 +119,19 @@ const processUrlApiConfig = async () => {
           globalStore.setFetchResult(true);
         } else {
           globalStore.setFetchResult(false);
-          localStorage.removeItem('backendConfigured');
-          localStorage.removeItem('magicPathConfigured');
 
-          if (route.path === '/subs') {
+          if (route.path === '/subs' && skippedCycle !== connectionCheckCycle.value) {
             showMagicPathDialog.value = true;
           }
         }
       } catch (e) {
         console.error('Error initializing stores:', e);
         globalStore.setFetchResult(false);
-        localStorage.removeItem('backendConfigured');
-        localStorage.removeItem('magicPathConfigured');
 
-        // 只在/subs路径下且连接出错时才显示弹窗
-        if (route.path === '/subs') {
+        // 检查用户是否跳过了当前连接检测周期
+        const skippedCycle = parseInt(sessionStorage.getItem('skippedConnectionCycle') || '0');
+
+        if (route.path === '/subs' && skippedCycle !== connectionCheckCycle.value) {
           showMagicPathDialog.value = true;
         }
       }
@@ -132,21 +139,36 @@ const processUrlApiConfig = async () => {
   });
 
   if (result) {
-    // URL参数指定的后端连接成功
+    // URL参数已处理（无论连接是否成功）
     urlApiConfigSuccess.value = true;
-    urlApiError.value = '';
-    showMagicPathDialog.value = false;
+
+    // 检查连接是否成功
+    const fetchResult = globalStore.fetchResult;
+
+    // 检查用户是否跳过了当前连接检测周期
+    const skippedCycle = parseInt(sessionStorage.getItem('skippedConnectionCycle') || '0');
+
+    if (fetchResult) {
+      // 连接成功，清除错误信息并隐藏弹窗
+      urlApiError.value = '';
+      showMagicPathDialog.value = false;
+    } else if (hasUrlParams && skippedCycle !== connectionCheckCycle.value) {
+      // 连接失败但已添加到后端列表，显示错误信息
+      // 保留urlApiError.value中的错误信息
+      if (route.path === '/subs') {
+        showMagicPathDialog.value = true;
+      }
+    }
 
     // 初始化stores，获取数据
     await initStores(false, true, false);
   } else {
+    // URL参数处理失败或没有URL参数
     if (hasUrlParams) {
-      // URL参数指定的后端连接失败
+      // URL参数处理失败
       globalStore.setFetchResult(false);
-      localStorage.removeItem('backendConfigured');
-      localStorage.removeItem('magicPathConfigured');
-
-      if (route.path === '/subs') {
+      const skippedCycle = parseInt(sessionStorage.getItem('skippedConnectionCycle') || '0');
+      if (route.path === '/subs' && skippedCycle !== connectionCheckCycle.value) {
         showMagicPathDialog.value = true;
       }
     } else {
@@ -157,26 +179,27 @@ const processUrlApiConfig = async () => {
         const hasBackendEnv = Object.keys(globalStore.env).length > 0 && globalStore.env.backend;
         const fetchResult = globalStore.fetchResult;
 
+        // 检查用户是否跳过了当前连接检测周期
+        const skippedCycle = parseInt(sessionStorage.getItem('skippedConnectionCycle') || '0');
+
         if (hasBackendEnv && fetchResult) {
           // 连接成功
           showMagicPathDialog.value = false;
           localStorage.setItem('backendConfigured', 'true');
         } else {
           // 连接失败
-          localStorage.removeItem('backendConfigured');
-          localStorage.removeItem('magicPathConfigured');
-
-          if (route.path === '/subs') {
+          if (route.path === '/subs' && skippedCycle !== connectionCheckCycle.value) {
             showMagicPathDialog.value = true;
           }
         }
       } catch (e) {
         console.error('Error initializing stores:', e);
         globalStore.setFetchResult(false);
-        localStorage.removeItem('backendConfigured');
-        localStorage.removeItem('magicPathConfigured');
 
-        if (route.path === '/subs') {
+        // 检查用户是否跳过了当前连接检测周期
+        const skippedCycle = parseInt(sessionStorage.getItem('skippedConnectionCycle') || '0');
+
+        if (route.path === '/subs' && skippedCycle !== connectionCheckCycle.value) {
           showMagicPathDialog.value = true;
         }
       }
@@ -207,6 +230,9 @@ watchEffect(() => {
   if (!globalStore.isLoading && !isBackendCheckInProgress.value) {
     // 使用setTimeout确保DOM已更新
     setTimeout(() => {
+      // 检查用户是否跳过了当前连接检测周期
+      const skippedCycle = parseInt(sessionStorage.getItem('skippedConnectionCycle') || '0');
+
       // 检查是否有环境信息
       const hasBackendEnv = Object.keys(globalStore.env).length > 0 && globalStore.env.backend;
       const fetchResult = globalStore.fetchResult;
@@ -215,11 +241,8 @@ watchEffect(() => {
         // 连接成功
         localStorage.setItem('backendConfigured', 'true');
         showMagicPathDialog.value = false;
-      } else if (!fetchResult) {
-        // 连接失败
-        localStorage.removeItem('backendConfigured');
-        localStorage.removeItem('magicPathConfigured');
-
+      } else if (!fetchResult && skippedCycle !== connectionCheckCycle.value) {
+        // 连接失败且用户没有跳过当前连接检测周期
         if (route.path === '/subs') {
           showMagicPathDialog.value = true;
         }
@@ -256,12 +279,17 @@ function checkAndShowMagicPathDialog() {
     return;
   }
 
+  // 检查用户是否跳过了当前连接检测周期
+  const skippedCycle = parseInt(sessionStorage.getItem('skippedConnectionCycle') || '0');
+
+  // 如果用户跳过了当前连接检测周期，则不显示弹窗
+  if (skippedCycle === connectionCheckCycle.value) {
+    return;
+  }
+
   // 如果后端连接失败且不在加载状态，显示弹窗
   const fetchResult = globalStore.fetchResult;
   if (!fetchResult && !globalStore.isLoading) {
-    localStorage.removeItem('backendConfigured');
-    localStorage.removeItem('magicPathConfigured');
-
     if (route.path === '/subs') {
       showMagicPathDialog.value = true;
     }
@@ -276,16 +304,22 @@ function checkAndShowMagicPathDialog() {
 
     // 如果有配置标志但没有环境信息，说明连接失败，需要显示配置弹窗
     if (!hasBackendEnv && !globalStore.isLoading) {
-      localStorage.removeItem('backendConfigured');
-      localStorage.removeItem('magicPathConfigured');
+      if (route.path === '/subs') {
+        showMagicPathDialog.value = true;
+      }
+      return;
     } else {
       // 连接成功，不显示弹窗
       return;
     }
   }
 
-  // 如果URL参数指定的后端连接成功，不显示弹窗
+  // 如果URL参数指定的后端已处理（无论连接是否成功），检查连接状态
   if (urlApiConfigSuccess.value) {
+    // 如果连接失败，显示弹窗
+    if (!fetchResult && route.path === '/subs') {
+      showMagicPathDialog.value = true;
+    }
     return;
   }
 
@@ -309,6 +343,14 @@ function checkNeedConfiguration() {
     return false;
   }
 
+  // 检查用户是否跳过了当前连接检测周期
+  const skippedCycle = parseInt(sessionStorage.getItem('skippedConnectionCycle') || '0');
+
+  // 如果用户跳过了当前连接检测周期，则不需要配置
+  if (skippedCycle === connectionCheckCycle.value) {
+    return false;
+  }
+
   const hasBackendEnv = Object.keys(globalStore.env).length > 0 && globalStore.env.backend;
   const fetchResult = globalStore.fetchResult;
 
@@ -329,9 +371,17 @@ function checkNeedConfiguration() {
     const hasApiParam = query.includes('api=');
     const hasMagicPathParam = query.includes('magicpath=');
 
-    // 如果URL中有参数但连接失败，需要配置
-    if ((hasApiParam || hasMagicPathParam) && !urlApiConfigSuccess.value) {
-      return true;
+    // 如果URL中有参数
+    if (hasApiParam || hasMagicPathParam) {
+      // 如果URL参数已处理但连接失败，需要配置
+      if (urlApiConfigSuccess.value && !fetchResult) {
+        return true;
+      }
+
+      // 如果URL参数未处理，需要配置
+      if (!urlApiConfigSuccess.value) {
+        return true;
+      }
     }
   }
 

--- a/src/components/MagicPathDialog.vue
+++ b/src/components/MagicPathDialog.vue
@@ -16,8 +16,8 @@
       <div class="title">{{ $t('magicPath.title') }}</div>
       <div class="description" v-html="$t('magicPath.description')"></div>
 
-      <!-- 显示URL参数错误信息 -->
-      <div v-if="props.urlApiError" class="url-api-error">
+      <!-- 显示URL参数错误信息 - 仅在非URL参数指定API的情况下显示 -->
+      <div v-if="props.urlApiError && !props.urlApiValue" class="url-api-error">
         <nut-icon name="failure" size="16"></nut-icon>
         <span>{{ props.urlApiError }}</span>
       </div>
@@ -96,6 +96,7 @@ const { addApi, setCurrent } = useHostAPI();
 const props = defineProps<{
   modelValue: boolean;
   urlApiError?: string;
+  urlApiValue?: string; // URL参数中指定的API地址
   connectionCycle?: number; // 当前的连接检测周期
 }>();
 
@@ -263,16 +264,26 @@ const validateInput = () => {
   return true;
 };
 
-// 当对话框关闭时重置状态，当对话框打开时检查URL参数错误
+// 当对话框关闭时重置状态，当对话框打开时检查URL参数错误和API值
 watch(visible, (newValue) => {
   if (!newValue) {
     magicPath.value = '';
     error.value = '';
     // 清除sessionStorage中的状态
     sessionStorage.removeItem('showMagicPathDialog');
-  } else if (newValue && props.urlApiError) {
-    // 如果有URL参数错误信息，显示在错误提示中
-    error.value = props.urlApiError;
+  } else if (newValue) {
+    // 如果对话框打开
+    if (props.urlApiValue) {
+      // 如果有URL参数指定的API地址，自动填入输入框
+      magicPath.value = props.urlApiValue;
+      // 如果有URL参数错误信息，显示在输入框下方的错误提示中
+      if (props.urlApiError) {
+        error.value = props.urlApiError;
+      }
+    } else if (props.urlApiError) {
+      // 如果只有URL参数错误信息，显示在错误提示中
+      error.value = props.urlApiError;
+    }
   }
 });
 
@@ -281,6 +292,14 @@ watch(() => props.urlApiError, (newValue) => {
   if (newValue && visible.value) {
     // 如果有新的URL参数错误信息且对话框正在显示，更新错误提示
     error.value = newValue;
+  }
+});
+
+// 监听URL参数API值的变化
+watch(() => props.urlApiValue, (newValue) => {
+  if (newValue && visible.value) {
+    // 如果有新的URL参数API值且对话框正在显示，更新输入框
+    magicPath.value = newValue;
   }
 });
 

--- a/src/components/MagicPathDialog.vue
+++ b/src/components/MagicPathDialog.vue
@@ -96,6 +96,7 @@ const { addApi, setCurrent } = useHostAPI();
 const props = defineProps<{
   modelValue: boolean;
   urlApiError?: string;
+  connectionCycle?: number; // 当前的连接检测周期
 }>();
 
 const emit = defineEmits<{
@@ -198,9 +199,20 @@ const handleSubmit = async () => {
 
 // 跳过配置
 const handleSkip = () => {
+  // 设置配置标志
   localStorage.setItem('backendConfigured', 'true');
   localStorage.setItem('magicPathConfigured', 'true'); // 兼容旧版本
+
+  // 记录用户跳过的连接检测周期
+  // 这样只有在当前连接检测周期内才会尊重用户的跳过选择
+  if (props.connectionCycle) {
+    sessionStorage.setItem('skippedConnectionCycle', props.connectionCycle.toString());
+  }
+
+  // 清除会话存储中的状态
   sessionStorage.removeItem('showMagicPathDialog');
+
+  // 关闭弹窗
   visible.value = false;
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -110,6 +110,10 @@ const viteConfig = defineConfig((mode: ConfigEnv) => {
           // globPatterns: ['**/*.{css,js,gz,eot,html,svg,png,ico,ttf,woff2}'],
           runtimeCaching: [
             {
+              urlPattern: /(^|\/.+)\/(api|download|share)\/.+/,
+              handler: "NetworkOnly",
+            },
+            {
               urlPattern: /.*\.(?:js|css|gz|html|json)/i, // json
               handler: "CacheFirst",
               options: {


### PR DESCRIPTION
- Always add URL-param backend to list and select it
- Persist last selected backend across reloads
- Make skip button temporary (not session-persistent)
- Show errors appropriately on subsequent failures
- Remove error message above input when custom API (from URL param) fails
- Auto-fill failed API URL into input for easy editing