### PR TITLE
chore(action): 增加用于更新 Vercel 项目设置的workflow

### DIFF
--- a/.github/workflows/update-vercel-project-settings.yml
+++ b/.github/workflows/update-vercel-project-settings.yml
@@ -1,0 +1,16 @@
+# 该 workflow 用于更新 Vercel 项目的 Node.js 版本
+name: Update Vercel project settings
+on:
+  workflow_dispatch:
+
+jobs:
+  update-nodejs-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Vercel project Node.js version
+        run: |
+          curl --request PATCH \
+          --url https://api.vercel.com/v9/projects/${{ secrets.PROJECT_ID }} \
+          --header 'Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}' \
+          --header 'Content-Type: application/json' \
+          --data '{ "nodeVersion":"22.x"}'


### PR DESCRIPTION
当前对应的 Vercel 项目中使用的16.x 已被废弃，该 Workflow 通过调用 Vercel API  来升级项目中对应的 Node.js 版本

<img width="1182" height="233" alt="image" src="https://github.com/user-attachments/assets/314e2503-1260-431f-8073-91bc209dc846" />


参考：[Vercel: Node.js 16 is being deprecated on January 31, 2025](https://vercel.com/changelog/node-js-16-deprecation)
