### PR TITLE
fix(theme): 适配 DarkReader 暗色主题检测

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,32 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
   <link rel="mask-icon" href="/favicon.svg" color="#FFFFFF" />
   <meta id="theme__color" name="theme-color" content="#000" />
+  <meta id="color__scheme" name="color-scheme" content="light dark" />
+  <script>
+    (function () {
+      var storageKey = 'sub-store-color-scheme';
+      var scheme = null;
+
+      try {
+        scheme = localStorage.getItem(storageKey);
+      } catch {}
+
+      if (scheme !== 'dark' && scheme !== 'light') {
+        scheme =
+          window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light';
+      }
+
+      document.documentElement.dataset.theme = scheme;
+      document.documentElement.style.setProperty('color-scheme', scheme);
+
+      var colorSchemeMeta = document.getElementById('color__scheme');
+      if (colorSchemeMeta) {
+        colorSchemeMeta.setAttribute('content', scheme);
+      }
+    })();
+  </script>
   <link rel="manifest" href="/manifests.json" />
   <style>
     html {
@@ -27,6 +53,7 @@
       height: 100vh;
       overflow-x: hidden;
       overflow-y: auto;
+      color-scheme: light dark;
     }
 
     body {

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -5,6 +5,10 @@ body {
   min-height: 100% !important;
 }
 
+html[data-darkreader-mode] body {
+  background-color: transparent !important;
+}
+
 a {
   color: inherit;
   text-decoration: none;

--- a/src/hooks/useThemes.ts
+++ b/src/hooks/useThemes.ts
@@ -5,6 +5,10 @@ import { ref, watchEffect } from 'vue';
 
 
 const mql = window.matchMedia('(prefers-color-scheme: dark)');
+const COLOR_SCHEME_META_ID = 'color__scheme';
+const COLOR_SCHEME_STORAGE_KEY = 'sub-store-color-scheme';
+
+type ColorScheme = 'light' | 'dark';
 
 // 通用变量
 const commonVariables = {
@@ -49,6 +53,25 @@ const getThemeModules = () => {
 };
 const modules = getThemeModules();
 
+const getColorScheme = (newMode: CustomTheme): ColorScheme => {
+  return modules[newMode]?.meta?.label === 'dark' ? 'dark' : 'light';
+};
+
+const syncColorScheme = (scheme: ColorScheme) => {
+  const root = document.documentElement;
+
+  root.dataset.theme = scheme;
+  root.style.setProperty('color-scheme', scheme);
+
+  const colorSchemeMeta = document.getElementById(COLOR_SCHEME_META_ID)
+    || document.querySelector('meta[name="color-scheme"]');
+  colorSchemeMeta?.setAttribute('content', scheme);
+
+  try {
+    localStorage.setItem(COLOR_SCHEME_STORAGE_KEY, scheme);
+  } catch {}
+};
+
 // 定义修改 root 变量方法
 const changeVariables = (newMode: CustomTheme) => {
   const map = { ...{ ...modules[newMode].colors }, ...commonVariables };
@@ -57,6 +80,8 @@ const changeVariables = (newMode: CustomTheme) => {
       document.documentElement.style.setProperty(`--${key}`, map[key]);
     });
   }
+
+  syncColorScheme(getColorScheme(newMode));
 
   // 切换浏览器窗口 / 状态栏颜色
   const themeColorMeta = document.getElementById('theme__color');


### PR DESCRIPTION
## 背景

Sub-Store 前端在启用 DarkReader 插件的浏览器中，页面缺少明确的暗色主题声明，DarkReader 等浏览器暗色主题插件可能无法识别页面已有自带暗色主题，从而再次施加暗色处理，导致界面观感异常。

<img width="322" height="203" alt="image" src="https://github.com/user-attachments/assets/6bef7916-d564-46db-a4dd-c49bd6c2561a" />


## 改动

- 在 HTML 入口声明 `color-scheme`，为浏览器和扩展提供标准的浅/深色能力信号。
- 在应用初始化前根据缓存或系统主题预同步 `html[data-theme]` 与 `color-scheme`，降低扩展抢先检测时的误判概率。
- 在运行时主题切换时同步更新：
  - `html[data-theme]`
  - CSS `color-scheme`
  - `meta[name="color-scheme"]`
  - 当前实际浅/深色方案缓存

## 影响

该改动不调整现有主题配色，不改变用户主题选择逻辑，也不影响页面布局。它只补充页面对当前配色方案的标准声明，使 DarkReader 等浏览器暗色主题工具能够更准确地识别页面已有暗色主题。

## 验证

- 在本地预览环境中确认页面 HTML 已包含 `color-scheme` 声明和初始化同步逻辑
- 使用 DarkReader 测试，确认前端的深色主题可被浏览器插件正确识别，不再被重复施加暗色处理

<img width="304" height="193" alt="image" src="https://github.com/user-attachments/assets/5313f6cb-5337-4adf-878b-80f4e4bbf9bc" />
